### PR TITLE
add ticks around resolved tags

### DIFF
--- a/app/ImageOverview.php
+++ b/app/ImageOverview.php
@@ -11,6 +11,10 @@ class ImageOverview
         $this->imagePath = $image;
     }
 
+    function code($str) {
+        return sprintf("`%s`", $str);
+    }
+
     /**
      * @return string
      * @throws \Exception
@@ -30,7 +34,7 @@ class ImageOverview
         foreach ($imageMeta['tags'] as $tag) {
             $rows[] = [
                 '`' . $tag['primary'] . '`',
-                implode(', ', $tag['dynamic']['resolved'])
+                implode(', ', array_map('code', $tag['dynamic']['resolved']))
             ];
         }
 


### PR DESCRIPTION
I wanted to see if I could get the equivalent resolved tags to be surrounded by ticks, so they show up as `1`, `1.29`, `1.29.1`, `1.29.1-r2` [here](https://edu.chainguard.dev/chainguard/chainguard-images/reference/deno/overview/):

<img width="526" alt="Screenshot 2023-01-31 at 11 02 24 AM" src="https://user-images.githubusercontent.com/210737/215813404-dc2bd213-9879-4d18-8a8f-41ccc7230d84.png">

I tried `composer install` then `./autodocs update images` which said it updated `../edu/content/...` but there weren't any changes. Maybe I'm just doing it wrong?

In any case, let me know if this is wrong (or rather, _how_ wrong it is 🤣), or if there's a better way to do this.