### PR TITLE
Grouping tags for tags history page

### DIFF
--- a/app/Command/Notify/SlackController.php
+++ b/app/Command/Notify/SlackController.php
@@ -31,6 +31,6 @@ class SlackController extends CommandController
             throw new \Exception("There was an error with the request.");
         }
 
-        $this->getPrinter()->success("Message sent.");
+        $this->success("Message sent.");
     }
 }


### PR DESCRIPTION
This PR updates tag history page to group tags by digest, which helps clarifying where the "latest" tag is pointing to.