### PR TITLE
Fixing tags table in overview pages

### DIFF
--- a/app/Page/ImageTags.php
+++ b/app/Page/ImageTags.php
@@ -72,12 +72,14 @@ class ImageTags extends ImageReferencePage
                 }
                 $tagsList .= ' ' . $this->code($tag['name']);
             }
-
-            $rows[] = [
-                $tagsList,
-                $relativeTime ? $this->getElapsedTime($interval) : $update->format('F jS'),
-                $this->code($digest)
-            ];
+            
+            if ($tagsList != "") {
+                $rows[] = [
+                    $tagsList,
+                    $relativeTime ? $this->getElapsedTime($interval) : $update->format('F jS'),
+                    $this->code($digest)
+                ];
+            }
         }
 
         return Mark::table($rows, ['Tag (s)', 'Last Changed', 'Digest']);


### PR DESCRIPTION
Fixing the tags table in overview pages. This table is supposed to only show `latest` and `latest-dev` info, while the full tags history is listed in the tags history page.