### PR TITLE
Fixed issue with image build + support to build subsets of pages

### DIFF
--- a/app/Builder/ImageReferenceBuilder.php
+++ b/app/Builder/ImageReferenceBuilder.php
@@ -57,7 +57,7 @@ class ImageReferenceBuilder extends DefaultBuilder
     /**
      * @throws FileNotFoundException
      */
-    public function buildDocsForImage(string $image, string $page = "all"): void
+    public function buildDocsForImage(string $image, string $pages = "all"): void
     {
         if (!is_dir($this->diffSourcePath . '/' . $image)) {
             $this->newImages[] = $image;
@@ -68,6 +68,7 @@ class ImageReferenceBuilder extends DefaultBuilder
             mkdir($savePath, 0777, true);
         }
 
+        $pagesArray = explode(',', $pages);
         $this->savePage($this->outputPath . '/' . $image . '/_index.md', $this->getIndexPage(
             $image,
             "Chainguard Images Reference: $image",
@@ -76,7 +77,7 @@ class ImageReferenceBuilder extends DefaultBuilder
 
         foreach ($this->referencePages as $referencePage)
         {
-            if ($page === "all" || $page === $referencePage->getName()) {
+            if ($pages === "all" || in_array($referencePage->getName(), $pagesArray)) {
                 $this->savePage(
                     $savePath . '/' . $referencePage->getSaveName($image),
                     $referencePage->getContent($image)

--- a/app/Command/Build/ImagesController.php
+++ b/app/Command/Build/ImagesController.php
@@ -41,11 +41,25 @@ class ImagesController extends CommandController
             }
             $imageName = $image['repo']['name'];
             $this->info("Building docs for the $imageName image...");
-            $imagesBuilder->buildDocsForImage($imageName, $this->getParam("page"));
+
+            $pages = "all";
+            if ($this->hasParam('pages')) {
+                $pages = $this->getParam('pages');
+            }
+
+            if (getenv('YAMLDOCS_BUILD_PAGES')) {
+                $pages = getenv('YAMLDOCS_BUILD_PAGES');
+            }
+
+            $imagesBuilder->buildDocsForImage($imageName, $pages);
         }
 
-        $imagesBuilder->saveChangelog();
-        $this->info("Latest changes saved to $imagesBuilder->lastUpdatePath.");
-        $this->info("Changelog saved to $imagesBuilder->changelogPath.");
+        if (!$this->hasFlag('skip-changelog')) {
+            $imagesBuilder->saveChangelog();
+            $this->info("Latest changes saved to $imagesBuilder->lastUpdatePath.");
+            $this->info("Changelog saved to $imagesBuilder->changelogPath.");
+        }
+
+        $this->info("Finished update. Output saved to $imagesBuilder->outputPath.");
     }
 }

--- a/tests/Feature/BuildTest.php
+++ b/tests/Feature/BuildTest.php
@@ -10,5 +10,5 @@ test('autodocs builder has ImageReferenceBuilder loaded with pages.', function (
     /** @var ImageReferenceBuilder $imagesBuilder */
     $imagesBuilder = $autodocs->getBuilder('images-reference');
     $this->assertInstanceOf(ImageReferenceBuilder::class, $imagesBuilder);
-    $this->assertCount(3, $imagesBuilder->referencePages);
+    $this->assertCount(4, $imagesBuilder->referencePages);
 });

--- a/yamldocs.yaml
+++ b/yamldocs.yaml
@@ -14,6 +14,7 @@ builders:
       - App\Page\ImageOverview
       - App\Page\ImageTags
       - App\Page\ImageProvenance
+      - App\Page\ImageSpecs
 
 templatesDir: templates
 cacheDir: workdir/cache


### PR DESCRIPTION
This fixes issue with image builds when a page= parameter was not provided.

Now it's possible to define a set of image pages to build instead of building all pages. This can be done as a parameter to the build command or as an ENV var.

```shell
./autodocs build images pages=tags,variants
```

Available pages:
- overview
- tags
- variants
- provenance

In addition to that, the new `--skip-changelog` flag will skip changelog creation.